### PR TITLE
fixed which csv file in data/ gets read in geographical page

### DIFF
--- a/brainhack_book/geographical_distribution.ipynb
+++ b/brainhack_book/geographical_distribution.ipynb
@@ -44,7 +44,7 @@
     "geo_df.columns = [\"country\", \"geometry\"]\n",
     "\n",
     "# Read brainhack data\n",
-    "event_df = pd.read_csv(fnames[0])\n",
+    "event_df = pd.read_csv(fnames[1])\n",
     "\n",
     "# Plot event locations\n",
     "# ToDo\n",


### PR DESCRIPTION
Before, it loaded the first file in data, which changed when "acknowledgements.csv" was added. Now, it pulls second element in list.

Maybe future iterations should specify the exact filename to avoid similar problems.